### PR TITLE
h : playtime 음수 에러

### DIFF
--- a/app/my-page/page.tsx
+++ b/app/my-page/page.tsx
@@ -14,7 +14,7 @@ export default async function MyPage(){
             <div className="main-container">
                 <ProfileContainer userdata={userdata} />
             </div>
-            {/* <SaveSimilarWordsContainer /> */}
+            <SaveSimilarWordsContainer />
         </>
     )
 }

--- a/util/hooks/useGetPlaytime.tsx
+++ b/util/hooks/useGetPlaytime.tsx
@@ -33,6 +33,12 @@ export default function useGetPlayTime(){
 
         let playtime = endTime - startTime;
 
+        /** playime의 값이 음수라면 (자정 이전 플레이하다가 자정 이후 정답을 맞혔을 경우) */
+        if(playtime < 0){
+            // 자정의 time 값(24*60+0 = 1440) 에서 시작한 시간을 빼고, endTime의 값을 더한다
+            playtime = (1440 - startTime) + endTime;
+        }
+
         // playtime store에 playtime 계산한 업데이트
         setPlayTimeState(playtime);
 


### PR DESCRIPTION
자정 이전에 플레이하다가 정답을 자정 이후에 맞히면 playtime 음수 에러가 발생한다.

가령 저녁11시 40분의 time은 23*60+40 = 1,420 이고 자정 이후 12시 5분의 time은 0*60+5 = 5 의 값을 가진다.

기존 playtime을 계산할때는 시작시간 (위 경우에서 11시 40분) 을 종료시간 (위 경우에서 12시 5분) 을 뺀 값을 활용했다.  하지만 위와같은 경우에서 얻어지는 playtime은 5 - 1420 = -1415라는 음수의 값을 가져 오류가 발생하게 된다.

위 오류를 해결하기 위해 playtime이 음수의 값을 가질 때에는 (자정 시간 - 시작시간) + 종료 시간으로 playtime의 값을 구해야한다.

자정 시간은 0시 0분이기도 하면서 24시 0분이기도 하다. 즉, 24 * 60 + 0 = 1,440 혹은 0이 자정 시간이다. 

이렇게 새롭게 얻은 playtime은 (1440 - 1420) + 5 = 25로 정상적인 playtime 값을 가지게 된다.